### PR TITLE
Unix walkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,13 @@ Index  Information           bytes
    20  File index comp size    4
    24  Archive comp size       4
    28  Number of fname blocks  4
-   32  Flatsize of file index  4
-   36  Flatsize of archive     5
-   41  Flatsize of Metadata    3
-   44  padding                20
+   32  Flatsize of metadata    4
+   36  Flatsize of file index  4
+   40  Flatsize of archive     8
+   48  unused1                 4
+   52  unused2                 4
+   56  unused3                 4
+   60  unused4                 4
 ```
 The first 64 bytes provides the number of groups, owners and files contained in the archive.
 It also contains the compressed size in bytes of the next three blocks.  The index of

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The archive contains 4 non-aligned sequential blocks.
 
 ### Block 1
 
-32 bytes
+64 bytes
 ```
 Index  Information           bytes
 ------------------------------------------------------------
@@ -53,18 +53,22 @@ Index  Information           bytes
     8  Number of link blocks   4
    12  Number of files         4
    16  Metadata comp size      4
-   20  Files data comp size    4
+   20  File index comp size    4
    24  Archive comp size       4
    28  Number of fname blocks  4
+   32  Flatsize of file index  4
+   36  Flatsize of archive     5
+   41  Flatsize of Metadata    3
+   44  padding                20
 ```
-The first 32 bytes provides the number of groups, owners and files contained in the archive.
+The first 64 bytes provides the number of groups, owners and files contained in the archive.
 It also contains the compressed size in bytes of the next three blocks.  The index of
 each block can easily be calculated:
 
     Block 1 index =  0
-    Block 2 index = 32
-    Block 3 index = 32 + length of block 2
-    Block 4 index = 32 + length of block 2 + length of block 3
+    Block 2 index = 64
+    Block 3 index = 64 + length of block 2
+    Block 4 index = 64 + length of block 2 + length of block 3
 
 
 ### Block 2
@@ -74,7 +78,7 @@ By reading the first two blocks of the RVN archive, the manifest can be surgical
 extracted without unrolling the entire file.
 
 Due to the nature of this block being reserved for metadata, the size of the
-uncompressed file is limited to 256 kb (262,144 bytes) by rule.
+uncompressed file is limited to 512 kb (524,288 bytes) by rule.
 
 ### Block 3
 

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -593,6 +593,10 @@ package body Archive.Pack is
       block.size_filedata   := AS.ndx_size;
       block.size_archive    := AS.tmp_size;
       block.fname_blocks    := file_index (Float'Ceiling (nfbfloat));
+      block.flat_metadata   := AS.flat_meta;
+      block.flat_filedata   := AS.flat_ndx;
+      block.flat_archive    := AS.flat_arc;
+      block.padding         := (others => 0);
 
       declare
          package Premier_IO is new Ada.Direct_IO (premier_block);
@@ -762,6 +766,7 @@ package body Archive.Pack is
       if out_succ then
          AS.print (debug, "Compressed index from" & archive_size'Img & " to" & out_size'Img);
          AS.ndx_size := zstd_size (out_size);
+         AS.flat_ndx := zstd_size (archive_size);
       else
          AS.print (normal, "Failed to compress " & uncompressed_archive);
       end if;
@@ -790,6 +795,7 @@ package body Archive.Pack is
       if out_succ then
          AS.print (debug, "Compressed archive from" & archive_size'Img & " to" & out_size'Img);
          AS.tmp_size := zstd_size (out_size);
+         AS.flat_arc := size_type (archive_size);
       else
          AS.print (normal, "Failed to compress " & uncompressed_archive);
       end if;
@@ -822,8 +828,8 @@ package body Archive.Pack is
       begin
          dossier_size := ZST.File_Size (DIR.Size (metadata_path));
 
-         if dossier_size > ZST.File_Size (KB256)  then
-            AS.print (normal, "The metadata file size exceeds the 256 KB limit.");
+         if dossier_size > ZST.File_Size (KB512)  then
+            AS.print (normal, "The metadata file size exceeds the 512 KB limit.");
             AS.print (normal, "The archive will be built without this file.");
             return;
          end if;
@@ -840,6 +846,7 @@ package body Archive.Pack is
          if out_succ then
             AS.print (debug, "Compressed metadata from" & dossier_size'Img & " to" & out_size'Img);
             AS.meta_size := zstd_size (out_size);
+            AS.flat_meta := mdata_size (dossier_size);
          else
             AS.print (normal, "Failed to compress " & metadata_path);
          end if;

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -345,8 +345,6 @@ package body Archive.Pack is
 
          AS.print (debug, "file = " & item_path & " (" & features.ftype'Img & ")");
       exception
-         when DIR.Name_Error =>
-            AS.print (normal, "walkfiles: " & dir_path & " directory does not exist");
          when failed : others =>
             AS.print (normal, "walkfiles exception => " & EX.Exception_Information (failed) &
                         "  file: " & item_path);
@@ -357,7 +355,6 @@ package body Archive.Pack is
       dirfiles.Iterate (walkdir'Access);
 
       AS.print (verbose, "cd " & dir_path);
-
       dirfiles.Iterate (walkfiles'Access);
 
    exception

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -789,6 +789,7 @@ package body Archive.Pack is
       archive_size : constant ZST.File_Size := ZST.File_Size (DIR.Size (uncompressed_archive));
    begin
       AS.tmp_size := 0;
+      AS.flat_arc := 0;
       ZST.incorporate_regular_file
         (filename    => uncompressed_archive,
          size        => archive_size,
@@ -813,6 +814,7 @@ package body Archive.Pack is
    procedure write_metadata_block (AS : in out Arc_Structure; metadata_path : String) is
    begin
       AS.meta_size := 0;
+      AS.flat_meta := 0;
       if metadata_path = "" then
          AS.print (debug, "No metadata file has been provided.");
          return;

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -580,6 +580,7 @@ package body Archive.Pack is
       block    : premier_block;
       nlbfloat : constant Float := Float (AS.links.Length) / 32.0;
       nfbfloat : constant Float := Float (AS.fnames.Length) / 32.0;
+      zeroes   : constant B_padding := (others => 0);
    begin
       SIO.Close (AS.rvn_handle);
 
@@ -595,8 +596,13 @@ package body Archive.Pack is
       block.fname_blocks    := file_index (Float'Ceiling (nfbfloat));
       block.flat_metadata   := AS.flat_meta;
       block.flat_filedata   := AS.flat_ndx;
-      block.flat_archive    := AS.flat_arc;
-      block.padding         := (others => 0);
+      block.flat_arc_mod    := size_modulo (AS.flat_arc mod 2 ** 32);
+      block.flat_arc_mult   := size_multi (AS.flat_arc / 2 ** 32);
+      block.unused1         := zeroes;
+      block.unused2         := zeroes;
+      block.unused3         := zeroes;
+      block.unused4         := zeroes;
+      block.unused5         := zeroes;
 
       declare
          package Premier_IO is new Ada.Direct_IO (premier_block);

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -593,15 +593,13 @@ package body Archive.Pack is
       block.size_filedata   := AS.ndx_size;
       block.size_archive    := AS.tmp_size;
       block.fname_blocks    := file_index (Float'Ceiling (nfbfloat));
-      block.flat_metadata   := AS.flat_meta;
+      block.flat_metadata   := zstd_size (AS.flat_meta);
       block.flat_filedata   := AS.flat_ndx;
-      block.flat_arc_mod    := size_modulo (AS.flat_arc mod 2 ** 32);
-      block.flat_arc_mult   := size_multi (AS.flat_arc / 2 ** 32);
+      block.flat_archive    := exabytes (AS.flat_arc);
       block.unused1         := 0;
       block.unused2         := 0;
       block.unused3         := 0;
       block.unused4         := 0;
-      block.unused5         := 0;
 
       declare
          package Premier_IO is new Ada.Direct_IO (premier_block);

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -367,7 +367,7 @@ package body Archive.Pack is
 
 
    ------------------------------------------------------------------------------------------
-   --  record_redirectory
+   --  record_directory
    ------------------------------------------------------------------------------------------
    procedure record_directory (AS : in out Arc_Structure; top_directory : String)
    is
@@ -462,7 +462,7 @@ package body Archive.Pack is
    ------------------------------------------------------------------------------------------
    procedure push_link (AS : in out Arc_Structure; link : String) is
    begin
-      AS.print (debug, "Pushing " & link & " link to stack");
+      AS.print (debug, "Pushing " & link & " link target to stack");
       for index in link'Range loop
          AS.links.Append (link (index));
       end loop;
@@ -474,7 +474,7 @@ package body Archive.Pack is
    ------------------------------------------------------------------------------------------
    procedure push_filename (AS : in out Arc_Structure; simple_name : String) is
    begin
-      AS.print (debug, "Pushing " & simple_name & " file to stack");
+      AS.print (debug, "Pushing " & simple_name & " filename to stack");
       for index in simple_name'Range loop
          AS.fnames.Append (simple_name (index));
       end loop;

--- a/src/archive-pack.adb
+++ b/src/archive-pack.adb
@@ -580,7 +580,6 @@ package body Archive.Pack is
       block    : premier_block;
       nlbfloat : constant Float := Float (AS.links.Length) / 32.0;
       nfbfloat : constant Float := Float (AS.fnames.Length) / 32.0;
-      zeroes   : constant B_padding := (others => 0);
    begin
       SIO.Close (AS.rvn_handle);
 
@@ -598,11 +597,11 @@ package body Archive.Pack is
       block.flat_filedata   := AS.flat_ndx;
       block.flat_arc_mod    := size_modulo (AS.flat_arc mod 2 ** 32);
       block.flat_arc_mult   := size_multi (AS.flat_arc / 2 ** 32);
-      block.unused1         := zeroes;
-      block.unused2         := zeroes;
-      block.unused3         := zeroes;
-      block.unused4         := zeroes;
-      block.unused5         := zeroes;
+      block.unused1         := 0;
+      block.unused2         := 0;
+      block.unused3         := 0;
+      block.unused4         := 0;
+      block.unused5         := 0;
 
       declare
          package Premier_IO is new Ada.Direct_IO (premier_block);

--- a/src/archive-pack.ads
+++ b/src/archive-pack.ads
@@ -81,6 +81,9 @@ private
          tmp_size   : zstd_size := 0;
          ndx_size   : zstd_size := 0;
          meta_size  : zstd_size := 0;
+         flat_meta  : mdata_size := 0;
+         flat_ndx   : zstd_size := 0;
+         flat_arc   : size_type := 0;
          white_list : Whitelist.A_Whitelist;
          serror     : Boolean := False;
       end record;

--- a/src/archive-pack.ads
+++ b/src/archive-pack.ads
@@ -166,7 +166,7 @@ private
    --  an error occurs, 0 will be set for metadata (meaning it's not provided).
    procedure write_metadata_block (AS : in out Arc_Structure; metadata_path : String);
 
-   --  Write block 3 (the compressed concatentation of blocks FA .. FD)
+   --  Write block 3 (the compressed concatentation of blocks FA .. FE)
    procedure write_file_index_block (AS : in out Arc_Structure; output_file_path : String);
 
    --  Write block 4 (the compressed single archive)

--- a/src/archive-unpack.adb
+++ b/src/archive-unpack.adb
@@ -82,7 +82,7 @@ package body Archive.Unpack is
       DS.print (debug, "        compressed :" & DS.header.size_metadata'Img);
       DS.print (debug, "  file index bytes :" & DS.header.flat_filedata'Img);
       DS.print (debug, "        compressed :" & DS.header.size_filedata'Img);
-      DS.print (debug, "     archive bytes :" & DS.header.flat_archive'Img);
+      DS.print (debug, "     archive bytes :" & flat_archive_size (DS.header)'Img);
       DS.print (debug, "        compressed :" & DS.header.size_archive'Img);
       DS.print (debug, "             index :" & SIO.Index (DS.rvn_handle)'Img);
 
@@ -1047,7 +1047,7 @@ package body Archive.Unpack is
             DS.buffer := ASU.To_Unbounded_String
               (ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
                                data_length  => Natural (DS.header.size_archive),
-                               final_size   => ZST.File_Size (DS.header.flat_archive),
+                               final_size   => ZST.File_Size (flat_archive_size (DS.header)),
                                successful   => decomp_worked));
             DS.print (debug, "One shot archive decompression successful : " & decomp_worked'Img);
          end if;
@@ -1202,6 +1202,18 @@ package body Archive.Unpack is
 
 
    ------------------------------------------------------------------------------------------
+   --  flat_archive_size
+   ------------------------------------------------------------------------------------------
+   function flat_archive_size (header_block : premier_block) return size_type
+   is
+      result : size_type := size_type (header_block.flat_arc_mod);
+   begin
+      result := result + size_type (header_block.flat_arc_mult * (2 ** 32));
+      return result;
+   end flat_archive_size;
+
+
+   ------------------------------------------------------------------------------------------
    --  print_magic_block
    ------------------------------------------------------------------------------------------
    procedure print_magic_block (DS : DArc)
@@ -1217,7 +1229,7 @@ package body Archive.Unpack is
       DS.print (normal, "        compressed :" & DS.header.size_metadata'Img);
       DS.print (normal, "  file index bytes :" & DS.header.flat_filedata'Img);
       DS.print (normal, "        compressed :" & DS.header.size_filedata'Img);
-      DS.print (normal, "     archive bytes :" & DS.header.flat_archive'Img);
+      DS.print (normal, "     archive bytes :" & flat_archive_size (DS.header)'Img);
       DS.print (normal, "        compressed :" & DS.header.size_archive'Img);
    end print_magic_block;
 

--- a/src/archive-unpack.adb
+++ b/src/archive-unpack.adb
@@ -189,7 +189,7 @@ package body Archive.Unpack is
      (DS      : in out DArc;
       filepath : String)
    is
-      --  metadata is always starts on index of 32.
+      --  metadata is always starts on index of 64.
       --  Move to this point if not already there.
       --  However, this is unnecessary if metadata is zero bytes.
       use type SIO.Count;

--- a/src/archive-unpack.adb
+++ b/src/archive-unpack.adb
@@ -991,6 +991,8 @@ package body Archive.Unpack is
          DS.retrieve_file_index;
       end if;
       if SIO.Index (DS.rvn_handle) /= DS.b4_index then
+         DS.print (debug, "Stream index at" & SIO.Index (DS.rvn_handle)'Img & ", setting to " &
+                     DS.b4_index'Img);
          SIO.Set_Index (DS.rvn_handle, DS.b4_index);
       end if;
       DS.files.Iterate (extract'Access);

--- a/src/archive-unpack.adb
+++ b/src/archive-unpack.adb
@@ -82,7 +82,7 @@ package body Archive.Unpack is
       DS.print (debug, "        compressed :" & DS.header.size_metadata'Img);
       DS.print (debug, "  file index bytes :" & DS.header.flat_filedata'Img);
       DS.print (debug, "        compressed :" & DS.header.size_filedata'Img);
-      DS.print (debug, "     archive bytes :" & flat_archive_size (DS.header)'Img);
+      DS.print (debug, "     archive bytes :" & DS.header.flat_archive'Img);
       DS.print (debug, "        compressed :" & DS.header.size_archive'Img);
       DS.print (debug, "             index :" & SIO.Index (DS.rvn_handle)'Img);
 
@@ -1047,7 +1047,7 @@ package body Archive.Unpack is
             DS.buffer := ASU.To_Unbounded_String
               (ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
                                data_length  => Natural (DS.header.size_archive),
-                               final_size   => ZST.File_Size (flat_archive_size (DS.header)),
+                               final_size   => ZST.File_Size (DS.header.flat_archive),
                                successful   => decomp_worked));
             DS.print (debug, "One shot archive decompression successful : " & decomp_worked'Img);
          end if;
@@ -1202,18 +1202,6 @@ package body Archive.Unpack is
 
 
    ------------------------------------------------------------------------------------------
-   --  flat_archive_size
-   ------------------------------------------------------------------------------------------
-   function flat_archive_size (header_block : premier_block) return size_type
-   is
-      result : size_type := size_type (header_block.flat_arc_mod);
-   begin
-      result := result + size_type (header_block.flat_arc_mult * (2 ** 32));
-      return result;
-   end flat_archive_size;
-
-
-   ------------------------------------------------------------------------------------------
    --  print_magic_block
    ------------------------------------------------------------------------------------------
    procedure print_magic_block (DS : DArc)
@@ -1229,7 +1217,7 @@ package body Archive.Unpack is
       DS.print (normal, "        compressed :" & DS.header.size_metadata'Img);
       DS.print (normal, "  file index bytes :" & DS.header.flat_filedata'Img);
       DS.print (normal, "        compressed :" & DS.header.size_filedata'Img);
-      DS.print (normal, "     archive bytes :" & flat_archive_size (DS.header)'Img);
+      DS.print (normal, "     archive bytes :" & DS.header.flat_archive'Img);
       DS.print (normal, "        compressed :" & DS.header.size_archive'Img);
    end print_magic_block;
 

--- a/src/archive-unpack.adb
+++ b/src/archive-unpack.adb
@@ -78,13 +78,16 @@ package body Archive.Unpack is
       DS.print (debug, "     links defined :" & DS.header.link_blocks'Img);
       DS.print (debug, " filenames defined :" & DS.header.fname_blocks'Img);
       DS.print (debug, "      number files :" & DS.header.file_blocks'Img);
-      DS.print (debug, "    metadata bytes :" & DS.header.size_metadata'Img);
-      DS.print (debug, "  file index bytes :" & DS.header.size_filedata'Img);
-      DS.print (debug, "     archive bytes :" & DS.header.size_archive'Img);
+      DS.print (debug, "    metadata bytes :" & DS.header.flat_metadata'Img);
+      DS.print (debug, "        compressed :" & DS.header.size_metadata'Img);
+      DS.print (debug, "  file index bytes :" & DS.header.flat_filedata'Img);
+      DS.print (debug, "        compressed :" & DS.header.size_filedata'Img);
+      DS.print (debug, "     archive bytes :" & DS.header.flat_archive'Img);
+      DS.print (debug, "        compressed :" & DS.header.size_archive'Img);
       DS.print (debug, "             index :" & SIO.Index (DS.rvn_handle)'Img);
 
       DS.valid    := True;
-      DS.b2_index := 33;
+      DS.b2_index := 65;
       DS.b3_index := DS.b2_index + SIO.Count (DS.header.size_metadata);
       DS.b4_index := DS.b3_index + SIO.Count (DS.header.size_filedata);
 
@@ -202,9 +205,11 @@ package body Archive.Unpack is
       DS.print (debug, "Single pass decompression for metadata, comp size:" & metasize'Img);
       declare
          decompress_success : Boolean;
-         plain_text : constant String := ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
-                                                         data_length  => Natural (metasize),
-                                                         successful   => decompress_success);
+         plain_text : constant String :=
+           ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
+                           data_length  => Natural (DS.header.size_metadata),
+                           final_size   => ZST.File_Size (DS.header.flat_metadata),
+                           successful   => decompress_success);
       begin
          if decompress_success then
             DS.direct_file_creation (target_file => filepath,
@@ -232,6 +237,7 @@ package body Archive.Unpack is
       end if;
       return ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
                              data_length  => Natural (DS.header.size_metadata),
+                             final_size   => ZST.File_Size (DS.header.flat_metadata),
                              successful   => decompress_success);
    end extract_metadata;
 
@@ -476,6 +482,7 @@ package body Archive.Unpack is
             all_files : constant String :=
               ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
                               data_length  => Natural (DS.header.size_filedata),
+                              final_size   => ZST.File_Size (DS.header.flat_filedata),
                               successful   => decompress_success);
          begin
             if not decompress_success then
@@ -1040,6 +1047,7 @@ package body Archive.Unpack is
             DS.buffer := ASU.To_Unbounded_String
               (ZST.Decompress (archive_saxs => DS.rvn_stmaxs,
                                data_length  => Natural (DS.header.size_archive),
+                               final_size   => ZST.File_Size (DS.header.flat_archive),
                                successful   => decomp_worked));
             DS.print (debug, "One shot archive decompression successful : " & decomp_worked'Img);
          end if;
@@ -1205,9 +1213,12 @@ package body Archive.Unpack is
       DS.print (normal, "     owners blocks :" & DS.header.num_owners'Img);
       DS.print (normal, "      links blocks :" & DS.header.link_blocks'Img);
       DS.print (normal, "      dirs + files :" & DS.header.file_blocks'Img);
-      DS.print (normal, "    metadata bytes :" & DS.header.size_metadata'Img);
-      DS.print (normal, "  file index bytes :" & DS.header.size_filedata'Img);
-      DS.print (normal, "     archive bytes :" & DS.header.size_archive'Img);
+      DS.print (normal, "    metadata bytes :" & DS.header.flat_metadata'Img);
+      DS.print (normal, "        compressed :" & DS.header.size_metadata'Img);
+      DS.print (normal, "  file index bytes :" & DS.header.flat_filedata'Img);
+      DS.print (normal, "        compressed :" & DS.header.size_filedata'Img);
+      DS.print (normal, "     archive bytes :" & DS.header.flat_archive'Img);
+      DS.print (normal, "        compressed :" & DS.header.size_archive'Img);
    end print_magic_block;
 
 end Archive.Unpack;

--- a/src/archive-unpack.ads
+++ b/src/archive-unpack.ads
@@ -194,7 +194,4 @@ private
    --  the current user.  If it's not, it attempts to change mode to make it so.
    procedure prepare_for_overwrite (DS : DArc; file_path : String);
 
-   --  Convenient function to join the two flat archive values to a single one
-   function flat_archive_size (header_block : premier_block) return size_type;
-
 end Archive.Unpack;

--- a/src/archive-unpack.ads
+++ b/src/archive-unpack.ads
@@ -194,4 +194,7 @@ private
    --  the current user.  If it's not, it attempts to change mode to make it so.
    procedure prepare_for_overwrite (DS : DArc; file_path : String);
 
+   --  Convenient function to join the two flat archive values to a single one
+   function flat_archive_size (header_block : premier_block) return size_type;
+
 end Archive.Unpack;

--- a/src/archive.ads
+++ b/src/archive.ads
@@ -15,6 +15,7 @@ package Archive is
    type size_modulo is mod 2 ** 32;
    type size_type   is mod 2 ** 40;
    type zstd_size   is mod 2 ** 32;
+   type mdata_size  is mod 2 ** 24;
    type filetime    is mod 2 ** 64;
    type nanoseconds is mod 2 ** 32;
    type max_path    is mod 2 ** 16;
@@ -28,6 +29,7 @@ package Archive is
    subtype Some_magic is String (1 .. 3);
 
    type A_padding is array (1 .. 3) of one_byte;
+   type B_padding is array (1 .. 20) of one_byte;
 
    type File_Block is
       record
@@ -79,9 +81,13 @@ package Archive is
          size_filedata   : zstd_size;
          size_archive    : zstd_size;
          fname_blocks    : file_index;
+         flat_filedata   : zstd_size;
+         flat_archive    : size_type;
+         flat_metadata   : mdata_size;
+         padding         : B_padding;
       end record;
 
-   for premier_block'Size use 256;
+   for premier_block'Size use 512;
    for premier_block'Alignment use 8;
    for premier_block use
       record
@@ -95,10 +101,15 @@ package Archive is
          size_filedata   at 20 range  0 .. 31;
          size_archive    at 24 range  0 .. 31;
          fname_blocks    at 28 range  0 .. 31;
+         flat_filedata   at 32 range  0 .. 31;
+         flat_archive    at 36 range  0 .. 39;
+         flat_metadata   at 41 range  0 .. 23;
+         padding         at 44 range  0 .. 159;
       end record;
 
    magic : constant Some_magic := Character'Val (200) & Character'Val (100) & Character'Val (50);
    KB256 : constant Natural := 262_144;
-   format_version : constant one_byte := 2;
+   KB512 : constant Natural := 524_288;
+   format_version : constant one_byte := 3;
 
 end Archive;

--- a/src/archive.ads
+++ b/src/archive.ads
@@ -29,7 +29,7 @@ package Archive is
    subtype Some_magic is String (1 .. 3);
 
    type A_padding is array (1 .. 3) of one_byte;
-   type B_padding is array (1 .. 20) of one_byte;
+   type B_padding is array (1 .. 4) of one_byte;
 
    type File_Block is
       record
@@ -82,9 +82,14 @@ package Archive is
          size_archive    : zstd_size;
          fname_blocks    : file_index;
          flat_filedata   : zstd_size;
-         flat_archive    : size_type;
+         flat_arc_mod    : size_modulo;
+         flat_arc_mult   : size_multi;
          flat_metadata   : mdata_size;
-         padding         : B_padding;
+         unused1         : B_padding;
+         unused2         : B_padding;
+         unused3         : B_padding;
+         unused4         : B_padding;
+         unused5         : B_padding;
       end record;
 
    for premier_block'Size use 512;
@@ -95,16 +100,25 @@ package Archive is
          version         at  3 range  0 .. 7;
          num_groups      at  4 range  0 .. 15;
          num_owners      at  6 range  0 .. 15;
+
          link_blocks     at  8 range  0 .. 31;
          file_blocks     at 12 range  0 .. 31;
          size_metadata   at 16 range  0 .. 31;
          size_filedata   at 20 range  0 .. 31;
+
          size_archive    at 24 range  0 .. 31;
          fname_blocks    at 28 range  0 .. 31;
          flat_filedata   at 32 range  0 .. 31;
-         flat_archive    at 36 range  0 .. 39;
+         unused1         at 44 range  0 .. 31;
+
+         flat_arc_mod    at 36 range  0 .. 31;
+         flat_arc_mult   at 40 range  0 .. 7;
          flat_metadata   at 41 range  0 .. 23;
-         padding         at 44 range  0 .. 159;
+
+         unused2         at 48 range  0 .. 31;
+         unused3         at 52 range  0 .. 31;
+         unused4         at 56 range  0 .. 31;
+         unused5         at 60 range  0 .. 31;
       end record;
 
    magic : constant Some_magic := Character'Val (200) & Character'Val (100) & Character'Val (50);

--- a/src/archive.ads
+++ b/src/archive.ads
@@ -82,10 +82,10 @@ package Archive is
          size_archive    : zstd_size;
          fname_blocks    : file_index;
          flat_filedata   : zstd_size;
+         unused1         : zpadding;
          flat_arc_mod    : size_modulo;
          flat_arc_mult   : size_multi;
          flat_metadata   : mdata_size;
-         unused1         : zpadding;
          unused2         : zpadding;
          unused3         : zpadding;
          unused4         : zpadding;

--- a/src/archive.ads
+++ b/src/archive.ads
@@ -21,6 +21,7 @@ package Archive is
    type max_path    is mod 2 ** 16;
    type max_fname   is mod 2 ** 8;
    type inode_type  is mod 2 ** 64;
+   type exabytes    is mod 2 ** 64;
    type file_index  is mod 2 ** 32;
    type owngrp_id   is mod 2 ** 32;
    type zpadding    is mod 2 ** 32;
@@ -81,15 +82,13 @@ package Archive is
          size_filedata   : zstd_size;
          size_archive    : zstd_size;
          fname_blocks    : file_index;
+         flat_metadata   : zstd_size;
          flat_filedata   : zstd_size;
+         flat_archive    : exabytes;
          unused1         : zpadding;
-         flat_arc_mod    : size_modulo;
-         flat_arc_mult   : size_multi;
-         flat_metadata   : mdata_size;
          unused2         : zpadding;
          unused3         : zpadding;
          unused4         : zpadding;
-         unused5         : zpadding;
       end record;
 
    for premier_block'Size use 512;
@@ -108,16 +107,14 @@ package Archive is
          size_archive    at 24 range  0 .. 31;
          fname_blocks    at 28 range  0 .. 31;
 
-         flat_filedata   at 32 range  0 .. 31;
-         unused1         at 36 range  0 .. 31;
-         flat_arc_mod    at 40 range  0 .. 31;
-         flat_arc_mult   at 44 range  0 .. 7;
-         flat_metadata   at 45 range  0 .. 23;
+         flat_metadata   at 32 range  0 .. 31;
+         flat_filedata   at 36 range  0 .. 31;
+         flat_archive    at 40 range  0 .. 63;
 
-         unused2         at 48 range  0 .. 31;
-         unused3         at 52 range  0 .. 31;
-         unused4         at 56 range  0 .. 31;
-         unused5         at 60 range  0 .. 31;
+         unused1         at 48 range  0 .. 31;
+         unused2         at 52 range  0 .. 31;
+         unused3         at 56 range  0 .. 31;
+         unused4         at 60 range  0 .. 31;
       end record;
 
    magic : constant Some_magic := Character'Val (200) & Character'Val (100) & Character'Val (50);

--- a/src/archive.ads
+++ b/src/archive.ads
@@ -23,13 +23,13 @@ package Archive is
    type inode_type  is mod 2 ** 64;
    type file_index  is mod 2 ** 32;
    type owngrp_id   is mod 2 ** 32;
+   type zpadding    is mod 2 ** 32;
 
    subtype A_filename is String (1 .. 256);
    subtype A_checksum is String (1 .. 32);
    subtype Some_magic is String (1 .. 3);
 
    type A_padding is array (1 .. 3) of one_byte;
-   type B_padding is array (1 .. 4) of one_byte;
 
    type File_Block is
       record
@@ -85,11 +85,11 @@ package Archive is
          flat_arc_mod    : size_modulo;
          flat_arc_mult   : size_multi;
          flat_metadata   : mdata_size;
-         unused1         : B_padding;
-         unused2         : B_padding;
-         unused3         : B_padding;
-         unused4         : B_padding;
-         unused5         : B_padding;
+         unused1         : zpadding;
+         unused2         : zpadding;
+         unused3         : zpadding;
+         unused4         : zpadding;
+         unused5         : zpadding;
       end record;
 
    for premier_block'Size use 512;
@@ -100,20 +100,19 @@ package Archive is
          version         at  3 range  0 .. 7;
          num_groups      at  4 range  0 .. 15;
          num_owners      at  6 range  0 .. 15;
-
          link_blocks     at  8 range  0 .. 31;
          file_blocks     at 12 range  0 .. 31;
+
          size_metadata   at 16 range  0 .. 31;
          size_filedata   at 20 range  0 .. 31;
-
          size_archive    at 24 range  0 .. 31;
          fname_blocks    at 28 range  0 .. 31;
-         flat_filedata   at 32 range  0 .. 31;
-         unused1         at 44 range  0 .. 31;
 
-         flat_arc_mod    at 36 range  0 .. 31;
-         flat_arc_mult   at 40 range  0 .. 7;
-         flat_metadata   at 41 range  0 .. 23;
+         flat_filedata   at 32 range  0 .. 31;
+         unused1         at 36 range  0 .. 31;
+         flat_arc_mod    at 40 range  0 .. 31;
+         flat_arc_mult   at 44 range  0 .. 7;
+         flat_metadata   at 45 range  0 .. 23;
 
          unused2         at 48 range  0 .. 31;
          unused3         at 52 range  0 .. 31;

--- a/src/unix/archive-dirent-scan.adb
+++ b/src/unix/archive-dirent-scan.adb
@@ -1,0 +1,59 @@
+--  This file is covered by the Internet Software Consortium (ISC) License
+--  Reference: ../../License.txt
+
+package body Archive.Dirent.Scan is
+
+   ----------------------
+   --  scan_directory  --
+   ----------------------
+   procedure scan_directory
+     (directory : String;
+      crate     : in out dscan_crate.Vector)
+   is
+      c_directory : constant IC.char_array := IC.To_C (directory);
+      rc : IC.int;
+   begin
+      crate.Clear;
+      rc := walkdir_open_folder (c_directory);
+      case rc is
+         when 1 =>
+            raise dscan_open_failure;
+         when 2 =>
+            raise dscan_folder_already_open;
+         when others => null;
+      end case;
+
+      loop
+         declare
+            use type IC.Strings.chars_ptr;
+            centry : IC.Strings.chars_ptr;
+         begin
+            centry := walkdir_next_entry;
+            exit when centry = IC.Strings.Null_Ptr;
+
+            declare
+               filename : constant String := IC.Strings.Value (centry);
+               entity   : constant Directory_Entity := create_entity (directory, filename);
+            begin
+               if filename /= "." and then filename /= ".."
+               then
+                  crate.Append (entity);
+               end if;
+            end;
+         end;
+      end loop;
+
+      rc := walkdir_close_folder;
+      case rc is
+         when 1 =>
+            raise dscan_close_failure;
+         when 2 =>
+            raise dscan_folder_not_open;
+         when others => null;
+      end case;
+
+      dscan_sorting.Sort (crate);
+
+   end scan_directory;
+
+end Archive.Dirent.Scan;

--- a/src/unix/archive-dirent-scan.ads
+++ b/src/unix/archive-dirent-scan.ads
@@ -1,0 +1,40 @@
+--  This file is covered by the Internet Software Consortium (ISC) License
+--  Reference: ../../License.txt
+
+with Ada.Containers.Vectors;
+private with Interfaces.C.Strings;
+
+package Archive.Dirent.Scan is
+
+   package CON renames Ada.Containers;
+
+   package dscan_crate is new CON.Vectors
+     (Index_Type => Natural,
+      Element_Type => Directory_Entity);
+
+   --  Fills the given contain with the entities of the given directory.  The
+   --  container is sorted before the procedure returns.
+   procedure scan_directory
+     (directory : String;
+      crate     : in out dscan_crate.Vector);
+
+   dscan_folder_already_open : exception;
+   dscan_folder_not_open     : exception;
+   dscan_open_failure        : exception;
+   dscan_close_failure       : exception;
+
+private
+
+   package IC renames Interfaces.C;
+   package dscan_sorting is new dscan_crate.Generic_Sorting;
+
+   function walkdir_open_folder (path : IC.char_array) return IC.int;
+   pragma Import (C, walkdir_open_folder);
+
+   function walkdir_close_folder return IC.int;
+   pragma Import (C, walkdir_close_folder);
+
+   function walkdir_next_entry return IC.Strings.chars_ptr;
+   pragma Import (C, walkdir_next_entry);
+
+end Archive.Dirent.Scan;

--- a/src/unix/archive-dirent.adb
+++ b/src/unix/archive-dirent.adb
@@ -1,0 +1,50 @@
+--  This file is covered by the Internet Software Consortium (ISC) License
+--  Reference: ../../License.txt
+
+
+
+package body Archive.Dirent is
+
+
+   -------------------
+   --  simple_name  --
+   -------------------
+   function simple_name (item: Directory_Entity) return String is
+   begin
+      return ASU.To_String (Item.filename);
+   end simple_name;
+
+
+   -----------------
+   --  full_path  --
+   -----------------
+   function full_path (item : Directory_Entity) return String is
+   begin
+      return ASU.To_String (Item.directory) & "/" & ASU.To_String (Item.filename);
+   end full_path;
+
+
+   ---------------------
+   --  create_entity  --
+   ---------------------
+   function create_entity
+     (directory : String;
+      filename  : String) return Directory_Entity
+   is
+      result : Directory_Entity;
+   begin
+      result.directory := ASU.To_Unbounded_String (directory);
+      result.filename  := ASU.To_Unbounded_String (filename);
+      return result;
+   end create_entity;
+
+
+   ---------
+   --  <  --
+   ---------
+   function "<" (left, right : Directory_Entity) return Boolean is
+   begin
+      return ASU."<" (left.filename, right.filename);
+   end "<";
+
+end Archive.Dirent;

--- a/src/unix/archive-dirent.ads
+++ b/src/unix/archive-dirent.ads
@@ -1,0 +1,34 @@
+--  This file is covered by the Internet Software Consortium (ISC) License
+--  Reference: ../../License.txt
+
+private with Ada.Strings.Unbounded;
+
+package Archive.Dirent is
+
+   type Directory_Entity is tagged private;
+
+   --  Returns the filename of the directory entity (up to 255 characters)
+   function simple_name (item: Directory_Entity) return String;
+
+   --  Returns the absolute path of the directory entity
+   function full_path (item : Directory_Entity) return String;
+
+   --  Returns a new Directory_Entity object
+   function create_entity
+     (directory : String;
+      filename  : String) return Directory_Entity;
+
+   function "<" (left, right : Directory_Entity) return Boolean;
+
+private
+
+   package ASU renames Ada.Strings.Unbounded;
+
+   type Directory_Entity is tagged
+      record
+         filename  : ASU.Unbounded_String;
+         directory : ASU.Unbounded_String;
+      end record;
+
+
+end Archive.Dirent;

--- a/src/unix/walkdir.c
+++ b/src/unix/walkdir.c
@@ -1,0 +1,51 @@
+/*
+ * This file is covered by the Internet Software Consortium (ISC) License
+ * Reference: ../../License.txt
+ */
+
+#ifndef _WIN32
+
+#include <stdio.h>
+#include <dirent.h>
+
+DIR *FOLDER = NULL;
+
+int
+walkdir_open_folder (const char * path)
+{
+	if (FOLDER != NULL) {
+		return 2;
+	}
+
+	FOLDER = opendir (path);
+	if (FOLDER == NULL) {
+		return 1;
+	}
+	return 0;
+}
+
+int
+walkdir_close_folder ()
+{
+	if (FOLDER == NULL) {
+		return 2;
+	}
+	if (closedir (FOLDER) < 0) {
+		return 1;
+	}
+	return 0;
+}
+
+char *
+walkdir_next_entry () {
+	struct dirent *entry;
+
+	entry = readdir (FOLDER);
+	if (entry == NULL) {
+		return NULL;
+	}
+	return entry->d_name;
+}
+
+
+#endif /* __WIN32 */

--- a/src/unix/walkdir.c
+++ b/src/unix/walkdir.c
@@ -33,6 +33,7 @@ walkdir_close_folder ()
 	if (closedir (FOLDER) < 0) {
 		return 1;
 	}
+	FOLDER = NULL;
 	return 0;
 }
 

--- a/src/zstandard/zstandard.adb
+++ b/src/zstandard/zstandard.adb
@@ -74,15 +74,21 @@ package body Zstandard is
       srcSize     : constant IC.size_t := IC.size_t (source_data'Length);
 
       full_size   : constant Zstd_uint64 :=
-        ZSTD_getDecompressedSize
+        ZSTD_getFrameContentSize
           (src     => src (src'First)'Access,
            srcSize => srcSize);
 
       dstCapacity : constant IC.size_t := IC.size_t (full_size);
    begin
-      if full_size = 0 then
+      if full_size = ZSTD_CONTENTSIZE_UNKNOWN then
          successful := False;
-         return Warn_orig_size_fail;
+         return "Error: Flat size cannot be determined.";
+      elsif full_size = ZSTD_CONTENTSIZE_ERROR then
+         successful := False;
+         return "Error: invalid magic number or srcSize too small.";
+      elsif full_size = 0 then
+         successful := False;
+         return "Error: size is valid, but it evaluates to zero which is unexpected.";
       end if;
 
       declare

--- a/src/zstandard/zstandard.adb
+++ b/src/zstandard/zstandard.adb
@@ -64,6 +64,7 @@ package body Zstandard is
    ------------------
    function Decompress
      (source_data : String;
+      final_size  : File_Size;
       successful  : out Boolean) return String
    is
       type source_cdata is array (source_data'Range) of aliased IC.unsigned_char;
@@ -72,24 +73,8 @@ package body Zstandard is
 
       src         : source_cdata := string_to_cdata (source_data);
       srcSize     : constant IC.size_t := IC.size_t (source_data'Length);
-
-      full_size   : constant Zstd_uint64 :=
-        ZSTD_getFrameContentSize
-          (src     => src (src'First)'Access,
-           srcSize => srcSize);
-
-      dstCapacity : constant IC.size_t := IC.size_t (full_size);
+      dstCapacity : constant IC.size_t := IC.size_t (final_size);
    begin
-      if full_size = ZSTD_CONTENTSIZE_UNKNOWN then
-         successful := False;
-         return "Error: Flat size cannot be determined.";
-      elsif full_size = ZSTD_CONTENTSIZE_ERROR then
-         successful := False;
-         return "Error: invalid magic number or srcSize too small.";
-      elsif full_size = 0 then
-         successful := False;
-         return "Error: size is valid, but it evaluates to zero which is unexpected.";
-      end if;
 
       declare
          type cdestination is array (1 .. dstCapacity) of aliased IC.unsigned_char;
@@ -124,7 +109,8 @@ package body Zstandard is
    function Decompress
      (archive_saxs : SIO.Stream_Access;
       data_length  : Natural;
-      successful  : out Boolean) return String
+      final_size   : File_Size;
+      successful   : out Boolean) return String
    is
       type magazine_type is
          record
@@ -134,6 +120,7 @@ package body Zstandard is
    begin
       magazine_type'Read (archive_saxs, magazine);
       return Decompress (source_data => magazine.data,
+                         final_size  => final_size,
                          successful  => successful);
    exception
       when others =>

--- a/src/zstandard/zstandard.ads
+++ b/src/zstandard/zstandard.ads
@@ -44,6 +44,7 @@ package Zstandard is
    --  related error message.
    function Decompress
      (source_data : String;
+      final_size  : File_Size;
       successful  : out Boolean) return String;
 
    --  This function reads the entire block of compressed data from the archive and
@@ -52,6 +53,7 @@ package Zstandard is
    function Decompress
      (archive_saxs : SIO.Stream_Access;
       data_length  : Natural;
+      final_size   : File_Size;
       successful   : out Boolean) return String;
 
 


### PR DESCRIPTION
The branch started as a sandbox to reimplement directory walking.
This work was pretty straightforward and was finished quickly.
(as a side benefit of sorting the files, more than 1 Mb was saved in the matreshka test package)

During development I hit the issue where sometimes zstandard can't determine the final size of the extract.
The solution is to store the flat sizes of the metadata, file index, and archive block in the header block.
The 32-bit header block was full, so this was expanded to 64-bits to accommodate.

I had trouble with the 512-bit block taking 520 bits, which was tracked down to the 24-bit type.
(It was initially even bigger with a 5-byte type adding another 3 bytes as well).

It seems to work now, so merge the work so I can go back to the plist changes.

Also the zstandard interface was changed to use the new "get size" function to replace the deprecated one,
but it did not solve the problem and ultimate the change wasn't used.